### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,14 +5,14 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
-*.clw text
-*.inc text
-*.int text
-*.cwproj text
-*.sln text
+*.clw text eol=crlf
+*.inc text eol=crlf
+*.int text eol=crlf
+*.cwproj text eol=crlf
+*.sln text eol=crlf
 # Version control files 
-*.apv text
-*.dcv text
+*.apv text eol=crlf
+*.dcv text eol=crlf
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf


### PR DESCRIPTION
After the Webinar chat, just updated the crlf settings with this repo.

Line endings will be crlf

Not sure this repo was what Victor was looking at but thought I would clear the problem.

I did run a "git add --renormalize ." after but did not see any changes, so presume this repo probably is fine anyway.

Mark

